### PR TITLE
Customize headers & footers for all pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@
 
 title: Knoxbits Blog
 author: Bryan Knox
-email: ""
+# email:
 description: >- # this means to ignore newlines until "baseurl:"
   I love software development. It makes me happy.
 baseurl:
@@ -39,6 +39,7 @@ url: "https://bryanknox.github.io"
 
 twitter_username: bryanknoxbits
 github_username: bryanknox
+rss: subscribe via RSS
 
 # Build settings
 theme: minima

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Knoxbits Blog
+author: Bryan Knox
 email: ""
 description: >- # this means to ignore newlines until "baseurl:"
   I love software development. It makes me happy.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,9 +25,6 @@
         {%- include social.html -%}
       </div>
 
-      <div class="footer-col footer-col-3">
-        <p>{{- site.description | escape -}}</p>
-      </div>
     </div>
 
   </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,11 +3,12 @@
 
   <div class="wrapper">
 
-    <h2 class="footer-heading">{{ site.title | escape }}</h2>
-
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
         <ul class="contact-list">
+          <li>
+            <h2 class="footer-heading">{{ site.title | escape }}</h2>
+          </li>
           <li class="p-name">
             {%- if site.author -%}
               {{ site.author | escape }}
@@ -21,7 +22,7 @@
         </ul>
       </div>
 
-      <div class="footer-col footer-col-2">
+      <div class="footer-col footer-col-3">
         {%- include social.html -%}
       </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,6 +4,7 @@
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    <div class="k0x-site-tagline">&nbsp;-&nbsp;{{ site.description | escape }}</div>
 
     {%- if page_paths -%}
       <nav class="site-nav">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,7 +28,6 @@ layout: default
       {%- endfor -%}
     </ul>
 
-    <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
   {%- endif -%}
 
 </div>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,17 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+@import "minima";
+
+/**
+ * Everything below is custom, not part of the standard minima theme.
+ */
+
+.k0x-site-tagline {
+    @include relative-font-size(1.0);
+
+    font-weight: 300;
+    line-height: $base-line-height * $base-font-size * 2.5;
+    letter-spacing: -1px;
+  }


### PR DESCRIPTION
- Moved tagline (description) text to the header. It was in the footer.
- Moved RSS subscribe link to footer. It was at the bottom of the home page's list of posts.
- Added author name. Now displayed in footer.
- Moved site title in footer for tighter layout.

[AB#218](https://dev.azure.com/knoxbits/d0100851-2dc5-46c5-8610-8f42f950967e/_workitems/edit/218)